### PR TITLE
fix: remove large title from search page header

### DIFF
--- a/app/(index)/_layout.tsx
+++ b/app/(index)/_layout.tsx
@@ -12,6 +12,7 @@ export default function TabLayout() {
     <Stack
       screenOptions={{
         title: "Search",
+        headerLargeTitle: false,
       }}
     />
   );


### PR DESCRIPTION
Disable headerLargeTitle for the search page navigation stack