### PR TITLE
Remove large header title from search page

### DIFF
--- a/app/(index)/_layout.tsx
+++ b/app/(index)/_layout.tsx
@@ -12,6 +12,7 @@ export default function TabLayout() {
     <Stack
       screenOptions={{
         title: "Search",
+        headerLargeTitle: false,
       }}
     />
   );


### PR DESCRIPTION
Disable the large title style on the search page by setting
headerLargeTitle: false in the Stack screenOptions.

[Open in Expo Go](https://302.expo.app/u?url=exp://u.expo.dev/07793961-ad0c-43ca-bce1-301475ecd214/group/4f7352ac-caf4-4f6d-910b-41c6219113c9).